### PR TITLE
Fix potential integer overflow

### DIFF
--- a/src/gui/ManagerGUI.java
+++ b/src/gui/ManagerGUI.java
@@ -28,7 +28,7 @@ public final class ManagerGUI extends JFrame implements ActionListener, MiningLi
     public static final int WINDOW_WIDTH  = 300;
     public static final int WINDOW_HEIGHT = 480;
     
-    public static int nonceOffset = 10000000;
+    public static long nonceOffset = 10000000;
     
     private ArrayList<ClusterMiner> miners = null;
     private volatile boolean isMining      = false;


### PR DESCRIPTION
If the miner mines one block long enough it can cause an overflow. This makes it far more unlikely.

On a side note, why not make the miner drop a block and move to the next if it can't find a solution after offsets past 2 billion anyways?
